### PR TITLE
Suppress use of tput when no tty present

### DIFF
--- a/exe/path_helper
+++ b/exe/path_helper
@@ -90,10 +90,17 @@ require 'fileutils'
 
 module PathHelper
 
-  Normal    =`tput sgr0`
-  Red       =`tput setaf 1`
-  Green     =`tput setaf 2`
-  Yellow    =`tput setaf 3`
+  if STDOUT.isatty
+    Normal    = `tput sgr0`
+    Red       = `tput setaf 1`
+    Green     = `tput setaf 2`
+    Yellow    = `tput setaf 3`
+  else
+    Normal    = ''
+    Red       = ''
+    Green     = ''
+    Yellow    = ''
+  end
 
   HOME = Pathname(ENV["HOME"])
 


### PR DESCRIPTION
When using this most excellent helper on a Raspbian system, called from `.zshenv`, it produces annoying messages during the copy as no tty is present:

```
$ scp bonnet.zip raspberrypi.local:
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
```

This minor fix checks to see if STDOUT is a tty and replaces the `tput` outputs with empty strings if it isn't.
