### PR TITLE
Fix remaining invalid character errors in GitHub Actions

### DIFF
--- a/.github/actions/run-shell-tests/action.yml
+++ b/.github/actions/run-shell-tests/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Run setup
       shell: bash
       run: |
-        sudo bash -c 'cd /root && ruby exe/path_helper --setup --no-lib --quiet'
+        sudo bash -c 'cd /root && ./exe/path_helper --setup --no-lib --quiet'
         sudo cp -R spec/fixtures/moredirs/* /root/.config/paths
 
     - name: Run tests

--- a/.github/actions/run-shell-tests/action.yml
+++ b/.github/actions/run-shell-tests/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Run setup
       shell: bash
       run: |
-        sudo bash -c 'cd /root && ./exe/path_helper --setup --no-lib --quiet'
+        sudo bash -c 'cd /root && ruby exe/path_helper --setup --no-lib --quiet'
         sudo cp -R spec/fixtures/moredirs/* /root/.config/paths
 
     - name: Run tests

--- a/.github/workflows/path_helper_tests.yml
+++ b/.github/workflows/path_helper_tests.yml
@@ -58,8 +58,7 @@ jobs:
 
     - name: Run setup
       run: |
-        sudo bash -c 'cd /root && ./exe/path_helper --setup --no-lib --quiet'
-        sudo cp -R spec/fixtures/moredirs/* /root/.config/paths
+        sudo sh -x /tmp/install.sh
 
     - name: Run tests
       timeout-minutes: 10

--- a/spec/shell_spec.sh
+++ b/spec/shell_spec.sh
@@ -67,7 +67,7 @@ test_a_path(){
 	shift
 	local actual=$(mktemp)
 
-	ruby "$PWD/exe/path_helper" "${@}" > "$actual"
+	"$PWD/exe/path_helper" "${@}" > "$actual"
 
 	local expected="$PWD/spec/fixtures/results/${output_file}"
 
@@ -164,7 +164,7 @@ if test_setup; then
 	failures="${failures:+"$failures:"}setup_spec 1"
 fi
 
-ruby exe/path_helper --setup --no-lib --quiet
+./exe/path_helper --setup --no-lib --quiet
 cp -R spec/fixtures/moredirs/* ~/.config/paths
 
 # This should pass now because the setup has been run
@@ -216,14 +216,14 @@ fi
 
 # This should not be okay, therefore it should be a fail if
 # running it seems okay.
-if ruby "$PWD/exe/path_helper" 2>/dev/null; then
+if "$PWD/exe/path_helper" 2>/dev/null; then
 	PASS=1
 	failures="${failures:+"$failures:"}must provide an argument"
 fi
 
 # This should not be okay, therefore it should be a fail if
 # running it seems okay.
-if ruby "$PWD/exe/path_helper" -q 2>/dev/null; then
+if "$PWD/exe/path_helper" -q 2>/dev/null; then
 	PASS=1
 	failures="${failures:+"$failures:"}the kind of path must be declared"
 fi


### PR DESCRIPTION
The previous PR fixed docker/install.sh and spec/shell_spec.sh but missed two critical locations where path_helper was still being called directly without ruby:

1. .github/workflows/path_helper_tests.yml - Changed to use /tmp/install.sh which properly handles the setup and already has the ruby fix

2. .github/actions/run-shell-tests/action.yml - Changed ./exe/path_helper to ruby exe/path_helper

This completes the fix for the invalid character errors that were occurring when the Ruby script was executed as a shell script.