### PR TITLE
Add GitHub Action for Crystal binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,166 @@
+name: Release Crystal Binary
+
+on:
+  # Trigger on version tags (e.g., v4.0.0, v4.1.0)
+  push:
+    tags:
+      - 'v*.*.*'
+
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (e.g., v4.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - os: linux-x86_64
+            runner: ubuntu-latest
+            crystal: latest
+            artifact_name: path_helper-linux-x86_64
+            build_flags: --static
+          - os: macos-x86_64
+            runner: macos-13
+            crystal: latest
+            artifact_name: path_helper-macos-x86_64
+            build_flags: ""
+          - os: macos-arm64
+            runner: macos-14
+            crystal: latest
+            artifact_name: path_helper-macos-arm64
+            build_flags: ""
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+
+      - name: Install dependencies
+        run: shards install --production
+
+      - name: Build release binary
+        run: |
+          shards build --release --no-debug ${{ matrix.build_flags }}
+          chmod +x bin/path_helper
+
+      - name: Verify binary
+        run: |
+          ./bin/path_helper --version
+          file bin/path_helper
+
+      - name: Create tarball and checksum
+        run: |
+          tar -czf ${{ matrix.artifact_name }}.tar.gz -C bin path_helper
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            shasum -a 256 ${{ matrix.artifact_name }}.tar.gz > ${{ matrix.artifact_name }}.tar.gz.sha256
+          else
+            sha256sum ${{ matrix.artifact_name }}.tar.gz > ${{ matrix.artifact_name }}.tar.gz.sha256
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: |
+            ${{ matrix.artifact_name }}.tar.gz
+            ${{ matrix.artifact_name }}.tar.gz.sha256
+          retention-days: 5
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release-assets
+          find artifacts -type f \( -name "*.tar.gz" -o -name "*.sha256" \) -exec cp {} release-assets/ \;
+          ls -lah release-assets/
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          else
+            TAG=${GITHUB_REF#refs/tags/}
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          fi
+        env:
+          TAG: ${{ inputs.tag_name }}
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          cat > release_notes.md << 'EOF'
+          # path_helper ${{ steps.version.outputs.version }}
+
+          ## Pre-built Binaries
+
+          Download the appropriate binary for your platform:
+
+          - **Linux (x86_64)**: `path_helper-linux-x86_64.tar.gz`
+          - **macOS (Intel)**: `path_helper-macos-x86_64.tar.gz`
+          - **macOS (Apple Silicon)**: `path_helper-macos-arm64.tar.gz`
+
+          ### Installation
+
+          ```bash
+          # Download and extract (example for Linux)
+          tar -xzf path_helper-linux-x86_64.tar.gz
+
+          # Verify checksum
+          sha256sum -c path_helper-linux-x86_64.tar.gz.sha256
+
+          # Install (requires sudo)
+          sudo mv path_helper /usr/local/bin/
+          sudo chmod +x /usr/local/bin/path_helper
+          ```
+
+          ### Verification
+
+          ```bash
+          path_helper --version
+          ```
+
+          ## Changes
+
+          See [CHANGES.md](CHANGES.md) for details.
+          EOF
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: false
+          files: release-assets/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow automatically builds and releases pre-compiled Crystal binaries for Linux (x86_64) and macOS (Intel & Apple Silicon) when version tags are pushed.

Features:
- Triggers on version tags (v*.*.*)
- Manual workflow dispatch option
- Multi-platform builds (Linux x86_64, macOS Intel, macOS ARM64)
- Static linking on Linux for better portability
- Generates SHA256 checksums for verification
- Creates GitHub releases with pre-built binaries

Usage:
1. Update version in shard.yml and src/path_helper/version.cr
2. Commit the version changes
3. Create and push a git tag: git tag v4.0.1 && git push origin v4.0.1
4. The workflow will automatically build and create a release